### PR TITLE
Fix bg color of transaction parameters in dark mode

### DIFF
--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -398,7 +398,7 @@ export default function Home() {
                       ))}
                       <div className="flex flex-col space-y-2 w-full">
                         <Label>Parameters</Label>
-                        <pre className="bg-gray-100 p-2 rounded-md overflow-x-auto">
+                        <pre className="bg-gray-100 p-2 rounded-md overflow-x-auto dark:bg-zinc-900">
                           {JSON.stringify(result.transactionData?.parameters, null, 2)}
                         </pre>
                       </div>


### PR DESCRIPTION
Currently: 
<img width="1452" alt="image" src="https://github.com/user-attachments/assets/6ea071d4-09d5-4662-a9f6-6ce1ef65b34d">

With fix:
<img width="1457" alt="image" src="https://github.com/user-attachments/assets/053f19db-9fce-462e-a89b-86ff508a8b10">
