### PR TITLE
Support for Older Safe Versions in safehashpreview

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,71 @@
+name: 👮‍♂️ Sanity checks
+
+on: [push, pull_request, workflow_dispatch]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  prettify:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+        node_version:
+          - 22
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node_version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node_version }}
+
+      - name: Run Prettier
+        run: npx prettier -c '**/*.{md,yml,yaml}'
+
+  codespell:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run codespell
+        uses: codespell-project/actions-codespell@v2
+        with:
+          check_filenames: true
+          skip: ./.git
+
+  validate-links:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+        ruby_version:
+          - 3.4
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby_version }}
+          bundler-cache: true
+
+      - name: Install awesome_bot
+        run: gem install awesome_bot
+
+      - name: Validate URLs
+        run: awesome_bot ./*.md ./*.sh --allow-dupe --request-delay 0.4 --white-list https://opensea.io

--- a/README.md
+++ b/README.md
@@ -1,8 +1,44 @@
 # Safe Multisig Transaction Hashes
 
-This Bash [script](./safe_hashes.sh) calculates the Safe transaction hashes by retrieving transaction details from the [Safe transaction service API](https://docs.safe.global/core-api/transaction-service-overview) and computing both the domain and message hashes using the [EIP-712](https://eips.ethereum.org/EIPS/eip-712) standard.
+This repository contains both a Bash script and a web interface for calculating Safe transaction hashes. It helps users verify transaction hashes before signing them on hardware wallets by retrieving transaction details from the Safe transaction service API and computing the domain and message hashes using the EIP-712 standard.
 
-## Supported Networks
+## Web Interface
+
+A user-friendly web interface is available at [safehashpreview.com](https://www.safehashpreview.com) that makes it easy to:
+- Select from supported networks via dropdown
+- Enter Safe address and nonce
+- View calculated hashes and transaction details
+- Copy values with one click
+- Compare hashes with hardware wallet screen
+
+### Local Development
+
+To run the web interface locally:
+
+1. Clone the repository:
+```bash
+git clone git@github.com:josepchetrit12/safe-preview-app.git
+cd safe-preview-app
+```
+
+2. Install dependencies:
+```bash
+cd app/
+npm install
+```
+
+3. Run the development server:
+```bash
+npm run dev
+```
+
+4. Open [http://localhost:3000](http://localhost:3000) in your browser
+
+## Command Line Script
+
+The original Bash script is still available for command-line usage. See below for supported networks and usage instructions.
+
+### Supported Networks
 
 - Arbitrum (identifier: `arbitrum`, chain ID: `42161`)
 - Aurora (identifier: `aurora`, chain ID: `1313161554`)
@@ -26,95 +62,37 @@ This Bash [script](./safe_hashes.sh) calculates the Safe transaction hashes by r
 - X Layer (identifier: `xlayer`, chain ID: `195`)
 - ZKsync Era (identifier: `zksync`, chain ID: `324`)
 
-## Usage
-
-> [!NOTE]
-> Ensure that [`cast`](https://github.com/foundry-rs/foundry/tree/master/crates/cast) and [`chisel`](https://github.com/foundry-rs/foundry/tree/master/crates/chisel) are installed locally. For installation instructions, refer to this [guide](https://book.getfoundry.sh/getting-started/installation).
+### Script Usage
 
 ```console
 ./safe_hashes.sh [--help] [--list-networks] --network <network> --address <address> --nonce <nonce>
 ```
 
 **Options:**
+- `--help`: Display help message
+- `--list-networks`: List supported networks and chain IDs
+- `--network <network>`: Specify network (e.g., `ethereum`, `polygon`)
+- `--address <address>`: Specify Safe multisig address
+- `--nonce <nonce>`: Specify transaction nonce
 
-- `--help`: Display this help message.
-- `--list-networks`: List all supported networks and their chain IDs.
-- `--network <network>`: Specify the network (e.g., `ethereum`, `polygon`).
-- `--address <address>`: Specify the Safe multisig address.
-- `--nonce <nonce>`: Specify the transaction nonce.
-
-Before you invoke the script, make it executable:
-
+Make script executable before use:
 ```console
 chmod +x safe_hashes.sh
 ```
 
-## Example
-
-```console
-./safe_hashes.sh --network arbitrum --address 0x111CEEee040739fD91D29C34C33E6B3E112F2177 --nonce 234
-```
-
-The script will output the domain, message, and Safe transaction hashes, allowing you to easily verify them against the values displayed on your Ledger hardware wallet screen:
-
-```console
-===================================
-= Selected Network Configurations =
-===================================
-
-Network: arbitrum
-Chain ID: 42161
-
-========================================
-= Transaction Data and Computed Hashes =
-========================================
-
-> Transaction Data:
-Multisig address: 0x111CEEee040739fD91D29C34C33E6B3E112F2177
-To: 0x111CEEee040739fD91D29C34C33E6B3E112F2177
-Data: 0x0d582f130000000000000000000000000c75fa5a5f1c0997e3eea425cfa13184ed0ec9e50000000000000000000000000000000000000000000000000000000000000003
-Encoded message: 0xbb8310d486368db6bd6f849402fdd73ad53d316b5a4b2644ad6efe0f941286d8000000000000000000000000111ceeee040739fd91d29c34c33e6b3e112f21770000000000000000000000000000000000000000000000000000000000000000b34f85cea7c4d9f384d502fc86474cd71ff27a674d785ebd23a4387871b8cbfe00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ea
-Method: addOwnerWithThreshold
-Parameters: [
-  {
-    "name": "owner",
-    "type": "address",
-    "value": "0x0c75Fa5a5F1C0997e3eEA425cFA13184ed0eC9e5"
-  },
-  {
-    "name": "_threshold",
-    "type": "uint256",
-    "value": "3"
-  }
-]
-
-> Hashes:
-Domain hash: 0x1CF7F9B1EFE3BC47FE02FD27C649FEA19E79D66040683A1C86C7490C80BF7291
-Message hash: 0xD9109EA63C50ECD3B80B6B27ED5C5A9FD3D546C2169DFB69BFA7BA24CD14C7A5
-Safe transaction hash: 0x0cb7250b8becd7069223c54e2839feaed4cee156363fbfe5dd0a48e75c4e25b3
-```
-
-> To see an example of a standard ETH transfer, run the command: `./safe_hashes.sh --network ethereum --address 0x8FA3b4570B4C96f8036C13b64971BA65867eEB48 --nonce 39` and review the output.
-
-To list all supported networks:
-
-```console
-./safe_hashes.sh --list-networks
-```
-
 ## Trust Assumptions
 
-1. You trust my [script](./safe_hashes.sh) 😃.
-2. You trust Linux.
-3. You trust [Foundry](https://github.com/foundry-rs/foundry).
-4. You trust the [Safe transaction service API](https://docs.safe.global/core-api/transaction-service-overview).
-5. You trust [Ledger's secure screen](https://www.ledger.com/academy/topics/ledgersolutions/ledger-wallets-secure-screen-security-model).
+1. You trust the script and web interface code 😃
+2. You trust Linux
+3. You trust Foundry
+4. You trust the Safe transaction service API
+5. You trust Ledger's secure screen
 
-## Community-Maintained User Interface Implementations
+## Authors
 
-> [!IMPORTANT]
-> Please be aware that user interface implementations may introduce additional trust assumptions, such as relying on `npm` dependencies that have not undergone thorough review. Always verify and cross-reference with the main script.
+- Web Interface: [josepchetrit12](https://github.com/josepchetrit12) and [xaler5](https://github.com/xaler5) from OpenZeppelin
+- Original Script: [pcaversaccio](https://github.com/pcaversaccio)
 
-- [`safehashpreview.com`](https://www.safehashpreview.com):
-  - Code: [`josepchetrit12/safe-tx-hashes-util`](https://github.com/josepchetrit12/safe-tx-hashes-util)
-  - Authors: [`josepchetrit12`](https://github.com/josepchetrit12), [`xaler5`](https://github.com/xaler5)
+## License
+
+AGPL-3.0 license

--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
-# Safe Multisig Transaction Hashes
+# Safe Multisig Transaction Hashes <!-- omit from toc -->
+
+[![License: AGPL-3.0-only](https://img.shields.io/badge/License-AGPL--3.0--only-blue)](https://www.gnu.org/licenses/agpl-3.0)
+
+```console
+|)0/\/'T TR|\_|5T, \/3R1FY! 🫡
+```
 
 This repository contains both a Bash script and a web interface for calculating Safe transaction hashes. It helps users verify transaction hashes before signing them on hardware wallets by retrieving transaction details from the Safe transaction service API and computing the domain and message hashes using the EIP-712 standard.
 
+<<<<<<< HEAD
 ## Web Interface
 
 A user-friendly web interface is available at [safehashpreview.com](https://www.safehashpreview.com) that makes it easy to:
@@ -39,6 +46,24 @@ npm run dev
 The original Bash script is still available for command-line usage. See below for supported networks and usage instructions.
 
 ### Supported Networks
+=======
+> [!NOTE]
+> This Bash [script](./safe_hashes.sh) relies on the [Safe transaction service API](https://docs.safe.global/core-api/transaction-service-overview), which requires transactions to be proposed and _logged_ in the service before they can be retrieved. Consequently, the initial transaction proposer cannot access the transaction at the proposal stage, making this approach incompatible with 1-of-1 multisigs.[^1]
+
+> [!IMPORTANT]
+> All Safe multisig versions starting from `0.1.0` and newer are supported.
+
+- [Supported Networks](#supported-networks)
+- [Usage](#usage)
+  - [macOS Users: Upgrading Bash](#macos-users-upgrading-bash)
+    - [Optional: Set the New Bash as Your Default Shell](#optional-set-the-new-bash-as-your-default-shell)
+- [Safe Transaction Hashes](#safe-transaction-hashes)
+- [Safe Message Hashes](#safe-message-hashes)
+- [Trust Assumptions](#trust-assumptions)
+- [Community-Maintained User Interface Implementations](#community-maintained-user-interface-implementations)
+
+## Supported Networks
+>>>>>>> upstream/main
 
 - Arbitrum (identifier: `arbitrum`, chain ID: `42161`)
 - Aurora (identifier: `aurora`, chain ID: `1313161554`)
@@ -64,8 +89,11 @@ The original Bash script is still available for command-line usage. See below fo
 
 ### Script Usage
 
+> [!TIP]
+> For macOS users, please refer to the [macOS Users: Upgrading Bash](#macos-users-upgrading-bash) section.
+
 ```console
-./safe_hashes.sh [--help] [--list-networks] --network <network> --address <address> --nonce <nonce>
+./safe_hashes.sh [--help] [--list-networks] --network <network> --address <address> --nonce <nonce> --message <file>
 ```
 
 **Options:**
@@ -75,11 +103,24 @@ The original Bash script is still available for command-line usage. See below fo
 - `--address <address>`: Specify Safe multisig address
 - `--nonce <nonce>`: Specify transaction nonce
 
+<<<<<<< HEAD
 Make script executable before use:
+=======
+- `--help`: Display this help message.
+- `--list-networks`: List all supported networks and their chain IDs.
+- `--network <network>`: Specify the network (e.g., `ethereum`, `polygon`).
+- `--address <address>`: Specify the Safe multisig address.
+- `--nonce <nonce>`: Specify the transaction nonce (required for transaction hashes).
+- `--message <file>`: Specify the message file (required for off-chain message hashes).
+
+Before you invoke the [script](./safe_hashes.sh), make it executable:
+
+>>>>>>> upstream/main
 ```console
 chmod +x safe_hashes.sh
 ```
 
+<<<<<<< HEAD
 ## Trust Assumptions
 
 1. You trust the script and web interface code 😃
@@ -96,3 +137,207 @@ chmod +x safe_hashes.sh
 ## License
 
 AGPL-3.0 license
+=======
+> [!TIP]
+> The [script](./safe_hashes.sh) is already set as _executable_ in the repository, so you can run it immediately after cloning or pulling the repository without needing to change permissions.
+
+To enable _debug mode_, set the `DEBUG` environment variable to `true` before running the [script](./safe_hashes.sh):
+
+```console
+DEBUG=true ./safe_hashes.sh ...
+```
+
+This will print each command before it is executed, which is helpful when troubleshooting.
+
+### macOS Users: Upgrading Bash
+
+This [script](./safe_hashes.sh) requires Bash [`4.0`](https://tldp.org/LDP/abs/html/bashver4.html) or higher due to its use of associative arrays (introduced in Bash [`4.0`](https://tldp.org/LDP/abs/html/bashver4.html)). Unfortunately, macOS ships by default with Bash `3.2` due to licensing requirements. To use this [script](./safe_hashes.sh), install a newer version of Bash through [Homebrew](https://brew.sh):
+
+1. Install [Homebrew](https://brew.sh) if you haven't already:
+
+```console
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+2. Install the latest version of Bash:
+
+```console
+brew install bash
+```
+
+3. Verify that you are using Bash version [`4.0`](https://tldp.org/LDP/abs/html/bashver4.html) or higher:
+
+```console
+bash --version
+```
+
+#### Optional: Set the New Bash as Your Default Shell
+
+1. Find the path to your Bash installation (`BASH_PATH`):
+
+```console
+which bash
+```
+
+2. Add the new shell to the list of allowed shells:
+
+Depending on your Mac's architecture and where [Homebrew](https://brew.sh) installs Bash, you will use one of the following commands:
+
+```console
+# For Intel-based Macs or if Homebrew is installed in the default location.
+sudo bash -c 'echo /usr/local/bin/bash >> /etc/shells'
+```
+
+or
+
+```console
+# For Apple Silicon (M1/M2) Macs or if you installed Homebrew using the default path for Apple Silicon.
+sudo bash -c 'echo /opt/homebrew/bin/bash >> /etc/shells'
+```
+
+3. Set the new Bash as your default shell:
+
+```console
+chsh -s BASH_PATH
+```
+
+Make sure to replace `BASH_PATH` with the actual path you retrieved in step 1.
+
+## Safe Transaction Hashes
+
+To calculate the Safe transaction hashes for a specific transaction, you need to specify the `network`, `address`, and `nonce` parameters. An example:
+
+```console
+./safe_hashes.sh --network arbitrum --address 0x111CEEee040739fD91D29C34C33E6B3E112F2177 --nonce 234
+```
+
+The [script](./safe_hashes.sh) will output the domain, message, and Safe transaction hashes, allowing you to easily verify them against the values displayed on your Ledger hardware wallet screen:
+
+```console
+===================================
+= Selected Network Configurations =
+===================================
+
+Network: arbitrum
+Chain ID: 42161
+
+========================================
+= Transaction Data and Computed Hashes =
+========================================
+
+> Transaction Data:
+Multisig address: 0x111CEEee040739fD91D29C34C33E6B3E112F2177
+To: 0x111CEEee040739fD91D29C34C33E6B3E112F2177
+Value: 0
+Data: 0x0d582f130000000000000000000000000c75fa5a5f1c0997e3eea425cfa13184ed0ec9e50000000000000000000000000000000000000000000000000000000000000003
+Encoded message: 0xbb8310d486368db6bd6f849402fdd73ad53d316b5a4b2644ad6efe0f941286d8000000000000000000000000111ceeee040739fd91d29c34c33e6b3e112f21770000000000000000000000000000000000000000000000000000000000000000b34f85cea7c4d9f384d502fc86474cd71ff27a674d785ebd23a4387871b8cbfe00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ea
+Method: addOwnerWithThreshold
+Parameters: [
+  {
+    "name": "owner",
+    "type": "address",
+    "value": "0x0c75Fa5a5F1C0997e3eEA425cFA13184ed0eC9e5"
+  },
+  {
+    "name": "_threshold",
+    "type": "uint256",
+    "value": "3"
+  }
+]
+
+WARNING: The "addOwnerWithThreshold" function modifies the owners or threshold of the Safe. Proceed with caution!
+
+> Hashes:
+Domain hash: 0x1CF7F9B1EFE3BC47FE02FD27C649FEA19E79D66040683A1C86C7490C80BF7291
+Message hash: 0xD9109EA63C50ECD3B80B6B27ED5C5A9FD3D546C2169DFB69BFA7BA24CD14C7A5
+Safe transaction hash: 0x0cb7250b8becd7069223c54e2839feaed4cee156363fbfe5dd0a48e75c4e25b3
+```
+
+> To see an example of a standard ETH transfer, run the command: `./safe_hashes.sh --network ethereum --address 0x8FA3b4570B4C96f8036C13b64971BA65867eEB48 --nonce 39` and review the output.
+
+To list all supported networks:
+
+```console
+./safe_hashes.sh --list-networks
+```
+
+## Safe Message Hashes
+
+This [script](./safe_hashes.sh) not only calculates Safe transaction hashes but also supports computing the corresponding hashes for off-chain messages following the [EIP-712](https://eips.ethereum.org/EIPS/eip-712) standard. To calculate the Safe message hashes for a specific message, specify the `network`, `address`, and `message` parameters. The `message` parameter must specify a valid file containing the raw message. This can be either the file name or a relative path (e.g., `path/to/message.txt`). Note that the [script](./safe_hashes.sh) normalises line endings to `LF` (`\n`) in the message file.
+
+An example: Save the following message to a file named `message.txt`:
+
+```txt
+Welcome to OpenSea!
+
+Click to sign in and accept the OpenSea Terms of Service (https://opensea.io/tos) and Privacy Policy (https://opensea.io/privacy).
+
+This request will not trigger a blockchain transaction or cost any gas fees.
+
+Wallet address:
+0x657ff0d4ec65d82b2bc1247b0a558bcd2f80a0f1
+
+Nonce:
+ea499f2f-fdbc-4d04-92c4-b60aba887e06
+```
+
+Then, invoke the following command:
+
+```console
+./safe_hashes.sh --network sepolia --address 0x657ff0D4eC65D82b2bC1247b0a558bcd2f80A0f1 --message message.txt
+```
+
+The [script](./safe_hashes.sh) will output the raw message, along with the domain, message, and Safe message hashes, allowing you to easily verify them against the values displayed on your Ledger hardware wallet screen:
+
+```console
+===================================
+= Selected Network Configurations =
+===================================
+
+Network: sepolia
+Chain ID: 11155111
+
+====================================
+= Message Data and Computed Hashes =
+====================================
+
+> Message Data:
+Multisig address: 0x657ff0D4eC65D82b2bC1247b0a558bcd2f80A0f1
+Message: Welcome to OpenSea!
+
+Click to sign in and accept the OpenSea Terms of Service (https://opensea.io/tos) and Privacy Policy (https://opensea.io/privacy).
+
+This request will not trigger a blockchain transaction or cost any gas fees.
+
+Wallet address:
+0x657ff0d4ec65d82b2bc1247b0a558bcd2f80a0f1
+
+Nonce:
+ea499f2f-fdbc-4d04-92c4-b60aba887e06
+
+> Hashes:
+Raw message hash: 0xcb1a9208c1a7c191185938c7d304ed01db68677eea4e689d688469aa72e34236
+Domain hash: 0x611379C19940CAEE095CDB12BEBE6A9FA9ABB74CDB1FBD7377C49A1F198DC24F
+Message hash: 0xA5D2F507A16279357446768DB4BD47A03BCA0B6ACAC4632A4C2C96AF20D6F6E5
+Safe message hash: 0x1866b559f56261ada63528391b93a1fe8e2e33baf7cace94fc6b42202d16ea08
+```
+
+## Trust Assumptions
+
+1. You trust my [script](./safe_hashes.sh) 😃.
+2. You trust Linux.
+3. You trust [Foundry](https://github.com/foundry-rs/foundry).
+4. You trust the [Safe transaction service API](https://docs.safe.global/core-api/transaction-service-overview).
+5. You trust [Ledger's secure screen](https://www.ledger.com/academy/topics/ledgersolutions/ledger-wallets-secure-screen-security-model).
+
+## Community-Maintained User Interface Implementations
+
+> [!IMPORTANT]
+> Please be aware that user interface implementations may introduce additional trust assumptions, such as relying on `npm` dependencies that have not undergone thorough review. Always verify and cross-reference with the main [script](./safe_hashes.sh).
+
+- [`safehashpreview.com`](https://www.safehashpreview.com):
+  - Code: [`josepchetrit12/safe-tx-hashes-util`](https://github.com/josepchetrit12/safe-tx-hashes-util)
+  - Authors: [`josepchetrit12`](https://github.com/josepchetrit12), [`xaler5`](https://github.com/xaler5)
+
+[^1]: It is theoretically possible to query transactions prior to the first signature; however, this functionality is not incorporated into the main [script](https://github.com/pcaversaccio/safe-tx-hashes-util/blob/main/safe_hashes.sh). To do so, you would proceed through the [Safe UI](https://app.safe.global) as usual, stopping at the page where the transaction is signed or executed. At this point, the action is recorded in the [Safe Transaction Service API](https://docs.safe.global/core-api/transaction-service-overview), allowing you to retrieve the unsigned transaction by setting `trusted=false` in the [API](https://docs.safe.global/core-api/transaction-service-reference/mainnet#List-a-Safe's-Multisig-Transactions) query within your Bash script. For example, you might use a query such as: `https://safe-transaction-arbitrum.safe.global/api/v1/safes/0xB24A3AA250E209bC95A4a9afFDF10c6D099B3d34/multisig-transactions/?trusted=false&nonce=4`. This decision to not implement this feature avoids potential confusion caused by unsigned transactions in the queue, especially when multiple transactions share the same nonce, making it unclear which one to act upon. If this feature aligns with your needs, feel free to fork the [script](https://github.com/pcaversaccio/safe-tx-hashes-util/blob/main/safe_hashes.sh) and modify it as necessary.
+>>>>>>> upstream/main

--- a/README.md
+++ b/README.md
@@ -8,45 +8,6 @@
 
 This repository contains both a Bash script and a web interface for calculating Safe transaction hashes. It helps users verify transaction hashes before signing them on hardware wallets by retrieving transaction details from the Safe transaction service API and computing the domain and message hashes using the EIP-712 standard.
 
-<<<<<<< HEAD
-## Web Interface
-
-A user-friendly web interface is available at [safehashpreview.com](https://www.safehashpreview.com) that makes it easy to:
-- Select from supported networks via dropdown
-- Enter Safe address and nonce
-- View calculated hashes and transaction details
-- Copy values with one click
-- Compare hashes with hardware wallet screen
-
-### Local Development
-
-To run the web interface locally:
-
-1. Clone the repository:
-```bash
-git clone git@github.com:josepchetrit12/safe-preview-app.git
-cd safe-preview-app
-```
-
-2. Install dependencies:
-```bash
-cd app/
-npm install
-```
-
-3. Run the development server:
-```bash
-npm run dev
-```
-
-4. Open [http://localhost:3000](http://localhost:3000) in your browser
-
-## Command Line Script
-
-The original Bash script is still available for command-line usage. See below for supported networks and usage instructions.
-
-### Supported Networks
-=======
 > [!NOTE]
 > This Bash [script](./safe_hashes.sh) relies on the [Safe transaction service API](https://docs.safe.global/core-api/transaction-service-overview), which requires transactions to be proposed and _logged_ in the service before they can be retrieved. Consequently, the initial transaction proposer cannot access the transaction at the proposal stage, making this approach incompatible with 1-of-1 multisigs.[^1]
 
@@ -63,7 +24,6 @@ The original Bash script is still available for command-line usage. See below fo
 - [Community-Maintained User Interface Implementations](#community-maintained-user-interface-implementations)
 
 ## Supported Networks
->>>>>>> upstream/main
 
 - Arbitrum (identifier: `arbitrum`, chain ID: `42161`)
 - Aurora (identifier: `aurora`, chain ID: `1313161554`)
@@ -103,9 +63,6 @@ The original Bash script is still available for command-line usage. See below fo
 - `--address <address>`: Specify Safe multisig address
 - `--nonce <nonce>`: Specify transaction nonce
 
-<<<<<<< HEAD
-Make script executable before use:
-=======
 - `--help`: Display this help message.
 - `--list-networks`: List all supported networks and their chain IDs.
 - `--network <network>`: Specify the network (e.g., `ethereum`, `polygon`).
@@ -115,29 +72,10 @@ Make script executable before use:
 
 Before you invoke the [script](./safe_hashes.sh), make it executable:
 
->>>>>>> upstream/main
 ```console
 chmod +x safe_hashes.sh
 ```
 
-<<<<<<< HEAD
-## Trust Assumptions
-
-1. You trust the script and web interface code 😃
-2. You trust Linux
-3. You trust Foundry
-4. You trust the Safe transaction service API
-5. You trust Ledger's secure screen
-
-## Authors
-
-- Web Interface: [josepchetrit12](https://github.com/josepchetrit12) and [xaler5](https://github.com/xaler5) from OpenZeppelin
-- Original Script: [pcaversaccio](https://github.com/pcaversaccio)
-
-## License
-
-AGPL-3.0 license
-=======
 > [!TIP]
 > The [script](./safe_hashes.sh) is already set as _executable_ in the repository, so you can run it immediately after cloning or pulling the repository without needing to change permissions.
 
@@ -340,4 +278,3 @@ Safe message hash: 0x1866b559f56261ada63528391b93a1fe8e2e33baf7cace94fc6b42202d1
   - Authors: [`josepchetrit12`](https://github.com/josepchetrit12), [`xaler5`](https://github.com/xaler5)
 
 [^1]: It is theoretically possible to query transactions prior to the first signature; however, this functionality is not incorporated into the main [script](https://github.com/pcaversaccio/safe-tx-hashes-util/blob/main/safe_hashes.sh). To do so, you would proceed through the [Safe UI](https://app.safe.global) as usual, stopping at the page where the transaction is signed or executed. At this point, the action is recorded in the [Safe Transaction Service API](https://docs.safe.global/core-api/transaction-service-overview), allowing you to retrieve the unsigned transaction by setting `trusted=false` in the [API](https://docs.safe.global/core-api/transaction-service-reference/mainnet#List-a-Safe's-Multisig-Transactions) query within your Bash script. For example, you might use a query such as: `https://safe-transaction-arbitrum.safe.global/api/v1/safes/0xB24A3AA250E209bC95A4a9afFDF10c6D099B3d34/multisig-transactions/?trusted=false&nonce=4`. This decision to not implement this feature avoids potential confusion caused by unsigned transactions in the queue, especially when multiple transactions share the same nonce, making it unclear which one to act upon. If this feature aligns with your needs, feel free to fork the [script](https://github.com/pcaversaccio/safe-tx-hashes-util/blob/main/safe_hashes.sh) and modify it as necessary.
->>>>>>> upstream/main

--- a/app/app/api/calculate-hashes/route.ts
+++ b/app/app/api/calculate-hashes/route.ts
@@ -46,7 +46,7 @@ export async function GET(request: NextRequest) {
 
   try {
     const scriptPath = path.join(process.cwd(), '..', 'safe_hashes.sh')
-    const command = `${scriptPath} --network ${network} --address ${address} --nonce ${nonce} --output json`
+    const command = `${scriptPath} --network ${network} --address ${address} --nonce ${nonce} --json`
     const { stdout, stderr } = await execPromise(command)
 
     if (stderr) {

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -517,29 +517,34 @@ export default function Home() {
                         { key: "to", label: "To" },
                         { key: "data", label: "Data" },
                         { key: "encoded_message", label: "Encoded message" },
-                      ].map(({ key, label }) => (
-                        <div
-                          key={key}
-                          className="flex flex-col space-y-2 w-full"
-                        >
-                          <Label>{label}</Label>
-                          <div className="flex items-center space-x-2 w-full">
-                            <Input
-                              readOnly
-                              value={result.transaction?.[key as keyof typeof result.transaction]}
-                            />
-                            <CopyButton
-                              value={result.transaction?.[key as keyof typeof result.transaction] || ""}
-                              onCopy={() => {
-                                toast({
-                                  title: "Copied to clipboard",
-                                  description: `${label} has been copied to your clipboard.`,
-                                });
-                              }}
-                            />
+                      ].map(({ key, label }) => {
+                        const value = result.transaction?.[key as keyof typeof result.transaction];
+                        const stringValue = typeof value === 'string' ? value : '';
+                        
+                        return (
+                          <div
+                            key={key}
+                            className="flex flex-col space-y-2 w-full"
+                          >
+                            <Label>{label}</Label>
+                            <div className="flex items-center space-x-2 w-full">
+                              <Input
+                                readOnly
+                                value={stringValue}
+                              />
+                              <CopyButton
+                                value={stringValue}
+                                onCopy={() => {
+                                  toast({
+                                    title: "Copied to clipboard",
+                                    description: `${label} has been copied to your clipboard.`,
+                                  });
+                                }}
+                              />
+                            </div>
                           </div>
-                        </div>
-                      ))}
+                        );
+                      })}
                       <div className="flex flex-col space-y-2 w-full">
                         <Label>Method</Label>
                         <Input

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -36,6 +36,29 @@ interface FormData {
   nonce: string;
 }
 
+interface ApiResponse {
+  network: {
+    name: string;
+    chain_id: string;
+  };
+  transaction: {
+    multisig_address: string;
+    to: string;
+    value: string;
+    data: string;
+    encoded_message: string;
+    data_decoded: {
+      method: string;
+      parameters: any[];
+    };
+  };
+  hashes: {
+    domain_hash: string;
+    message_hash: string;
+    safe_transaction_hash: string;
+  };
+}
+
 const NETWORKS = [
   {
     value: "arbitrum",
@@ -190,8 +213,9 @@ export default function Home() {
   const searchParams = useSearchParams();
 
   const [result, setResult] = useState<{
-    hashes?: { [key: string]: string };
-    transactionData?: { [key: string]: any };
+    network?: ApiResponse["network"];
+    transaction?: ApiResponse["transaction"];
+    hashes?: ApiResponse["hashes"];
     error?: string;
     endpoint?: string;
   } | null>(null);
@@ -241,7 +265,7 @@ export default function Home() {
     setIsLoading(true);
     setResult(null);
     try {
-      const response = await axios.get(
+      const response = await axios.get<{ result: ApiResponse }>(
         `/api/calculate-hashes?network=${data.network}&address=${data.address}&nonce=${data.nonce}`
       );
       setResult(response.data.result);
@@ -489,11 +513,10 @@ export default function Home() {
                         Transaction Data
                       </h3>
                       {[
-                        { key: "multisigAddress", label: "Multisig address" },
+                        { key: "multisig_address", label: "Multisig address" },
                         { key: "to", label: "To" },
                         { key: "data", label: "Data" },
-                        { key: "encodedMessage", label: "Encoded message" },
-                        { key: "method", label: "Method" },
+                        { key: "encoded_message", label: "Encoded message" },
                       ].map(({ key, label }) => (
                         <div
                           key={key}
@@ -503,10 +526,10 @@ export default function Home() {
                           <div className="flex items-center space-x-2 w-full">
                             <Input
                               readOnly
-                              value={result.transactionData?.[key]}
+                              value={result.transaction?.[key as keyof typeof result.transaction]}
                             />
                             <CopyButton
-                              value={result.transactionData?.[key]}
+                              value={result.transaction?.[key as keyof typeof result.transaction] || ""}
                               onCopy={() => {
                                 toast({
                                   title: "Copied to clipboard",
@@ -518,10 +541,17 @@ export default function Home() {
                         </div>
                       ))}
                       <div className="flex flex-col space-y-2 w-full">
+                        <Label>Method</Label>
+                        <Input
+                          readOnly
+                          value={result.transaction?.data_decoded?.method || ""}
+                        />
+                      </div>
+                      <div className="flex flex-col space-y-2 w-full">
                         <Label>Parameters</Label>
-                        <pre className="bg-gray-100 p-2 rounded-md overflow-x-auto  dark:bg-zinc-900">
+                        <pre className="bg-gray-100 p-2 rounded-md overflow-x-auto dark:bg-zinc-900">
                           {JSON.stringify(
-                            result.transactionData?.parameters,
+                            result.transaction?.data_decoded?.parameters,
                             null,
                             2
                           )}
@@ -532,9 +562,9 @@ export default function Home() {
                     <div className="space-y-4">
                       <h3 className="text-lg font-semibold">Hashes</h3>
                       {[
-                        { key: "safeTransactionHash", label: "safeTxHash" },
-                        { key: "domainHash", label: "Domain hash" },
-                        { key: "messageHash", label: "Message hash" },
+                        { key: "safe_transaction_hash", label: "safeTxHash" },
+                        { key: "domain_hash", label: "Domain hash" },
+                        { key: "message_hash", label: "Message hash" },
                       ].map(({ key, label }) => (
                         <div
                           key={key}
@@ -542,9 +572,9 @@ export default function Home() {
                         >
                           <Label>{label}</Label>
                           <div className="flex items-center space-x-2 w-full">
-                            <Input readOnly value={result.hashes?.[key]} />
+                            <Input readOnly value={result.hashes?.[key as keyof typeof result.hashes]} />
                             <CopyButton
-                              value={result.hashes?.[key] || ""}
+                              value={result.hashes?.[key as keyof typeof result.hashes] || ""}
                               onCopy={() => {
                                 toast({
                                   title: "Copied to clipboard",

--- a/safe_hashes.sh
+++ b/safe_hashes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ########################
 # Don't trust, verify! #
@@ -7,97 +7,159 @@
 # @license GNU Affero General Public License v3.0 only
 # @author pcaversaccio
 
+# Set the terminal formatting constants.
+readonly GREEN="\e[32m"
+readonly RED="\e[31m"
+readonly UNDERLINE="\e[4m"
+readonly BOLD="\e[1m"
+readonly RESET="\e[0m"
+
+# Check the Bash version compatibility.
+if [[ "${BASH_VERSINFO[0]:-0}" -lt 4 ]]; then
+    echo -e "${BOLD}${RED}Error: This script requires Bash 4.0 or higher.${RESET}"
+    echo -e "${BOLD}${RED}Current version: $BASH_VERSION${RESET}"
+    echo -e "${BOLD}${RED}Please upgrade your Bash installation.${RESET}"
+    echo -e "${BOLD}${RED}If you've already upgraded via Homebrew, try running:${RESET}"
+    echo -e "${BOLD}${RED}/opt/homebrew/bin/bash $0 $@${RESET}"
+    exit 1
+fi
+
+# Utility function to ensure all required tools are installed.
+check_required_tools() {
+    local tools=("curl" "jq" "chisel" "cast")
+    local missing_tools=()
+
+    for tool in "${tools[@]}"; do
+        if ! command -v "$tool" &>/dev/null; then
+            missing_tools+=("$tool")
+        fi
+    done
+
+    if [[ ${#missing_tools[@]} -ne 0 ]]; then
+        echo -e "${BOLD}${RED}The following required tools are not installed:${RESET}"
+        for tool in "${missing_tools[@]}"; do
+            echo -e "${BOLD}${RED}  - $tool${RESET}"
+        done
+        echo -e "${BOLD}${RED}Please install them to run the script properly.${RESET}"
+        exit 1
+    fi
+}
+
+check_required_tools
+
 # Enable strict error handling:
+# -E: Inherit `ERR` traps in functions and subshells.
 # -e: Exit immediately if a command exits with a non-zero status.
 # -u: Treat unset variables as an error and exit.
 # -o pipefail: Return the exit status of the first failed command in a pipeline.
-set -euo pipefail
+set -Eeuo pipefail
 
-# Set the terminal formatting constants.
-readonly GREEN="\e[32m"
-readonly UNDERLINE="\e[4m"
-readonly RESET="\e[0m"
+# Enable debug mode if the environment variable `DEBUG` is set to `true`.
+if [[ "${DEBUG:-false}" == "true" ]]; then
+    # Print each command before executing it.
+    set -x
+fi
 
 # Set the type hash constants.
 # => `keccak256("EIP712Domain(uint256 chainId,address verifyingContract)");`
 # See: https://github.com/safe-global/safe-smart-account/blob/a0a1d4292006e26c4dbd52282f4c932e1ffca40f/contracts/Safe.sol#L54-L57.
-DOMAIN_SEPARATOR_TYPEHASH="0x47e79534a245952e8b16893a336b85a3d9ea9fa8c573f3d803afb92a79469218"
+readonly DOMAIN_SEPARATOR_TYPEHASH="0x47e79534a245952e8b16893a336b85a3d9ea9fa8c573f3d803afb92a79469218"
+# => `keccak256("EIP712Domain(address verifyingContract)");`
+# See: https://github.com/safe-global/safe-smart-account/blob/703dde2ea9882a35762146844d5cfbeeec73e36f/contracts/GnosisSafe.sol#L20-L23.
+readonly DOMAIN_SEPARATOR_TYPEHASH_OLD="0x035aff83d86937d35b32e04f0ddc6ff469290eef2f1b692d8a815c89404d4749"
 # => `keccak256("SafeTx(address to,uint256 value,bytes data,uint8 operation,uint256 safeTxGas,uint256 baseGas,uint256 gasPrice,address gasToken,address refundReceiver,uint256 nonce)");`
 # See: https://github.com/safe-global/safe-smart-account/blob/a0a1d4292006e26c4dbd52282f4c932e1ffca40f/contracts/Safe.sol#L59-L62.
-SAFE_TX_TYPEHASH="0xbb8310d486368db6bd6f849402fdd73ad53d316b5a4b2644ad6efe0f941286d8"
+readonly SAFE_TX_TYPEHASH="0xbb8310d486368db6bd6f849402fdd73ad53d316b5a4b2644ad6efe0f941286d8"
+# => `keccak256("SafeTx(address to,uint256 value,bytes data,uint8 operation,uint256 safeTxGas,uint256 dataGas,uint256 gasPrice,address gasToken,address refundReceiver,uint256 nonce)");`
+# See: https://github.com/safe-global/safe-smart-account/blob/427d6f7e779431333c54bcb4d4cde31e4d57ce96/contracts/GnosisSafe.sol#L25-L28.
+readonly SAFE_TX_TYPEHASH_OLD="0x14d461bc7412367e924637b363c7bf29b8f47e2f84869f4426e5633d8af47b20"
+# => `keccak256("SafeMessage(bytes message)");`
+# See: https://github.com/safe-global/safe-smart-account/blob/febab5e4e859e6e65914f17efddee415e4992961/contracts/libraries/SignMessageLib.sol#L12-L13.
+readonly SAFE_MSG_TYPEHASH="0x60b3cbf8b4a223d68d641b3b6ddf9a298e7f33710cf3d3a9d1146b5a6150fbca"
 
 # Define the supported networks from the Safe transaction service.
-# See https://docs.safe.global/core-api/transaction-service-supported-networks.
-declare -A API_URLS=(
-    [arbitrum]="https://safe-transaction-arbitrum.safe.global"
-    [aurora]="https://safe-transaction-aurora.safe.global"
-    [avalanche]="https://safe-transaction-avalanche.safe.global"
-    [base]="https://safe-transaction-base.safe.global"
-    [base-sepolia]="https://safe-transaction-base-sepolia.safe.global"
-    [blast]="https://safe-transaction-blast.safe.global"
-    [bsc]="https://safe-transaction-bsc.safe.global"
-    [celo]="https://safe-transaction-celo.safe.global"
-    [ethereum]="https://safe-transaction-mainnet.safe.global"
-    [gnosis]="https://safe-transaction-gnosis-chain.safe.global"
-    [gnosis-chiado]="https://safe-transaction-chiado.safe.global"
-    [linea]="https://safe-transaction-linea.safe.global"
-    [mantle]="https://safe-transaction-mantle.safe.global"
-    [optimism]="https://safe-transaction-optimism.safe.global"
-    [polygon]="https://safe-transaction-polygon.safe.global"
-    [polygon-zkevm]="https://safe-transaction-zkevm.safe.global"
-    [scroll]="https://safe-transaction-scroll.safe.global"
-    [sepolia]="https://safe-transaction-sepolia.safe.global"
-    [worldchain]="https://safe-transaction-worldchain.safe.global"
-    [xlayer]="https://safe-transaction-xlayer.safe.global"
-    [zksync]="https://safe-transaction-zksync.safe.global"
+# See https://docs.safe.global/advanced/smart-account-supported-networks?service=Transaction+Service.
+declare -A -r API_URLS=(
+    ["arbitrum"]="https://safe-transaction-arbitrum.safe.global"
+    ["aurora"]="https://safe-transaction-aurora.safe.global"
+    ["avalanche"]="https://safe-transaction-avalanche.safe.global"
+    ["base"]="https://safe-transaction-base.safe.global"
+    ["base-sepolia"]="https://safe-transaction-base-sepolia.safe.global"
+    ["blast"]="https://safe-transaction-blast.safe.global"
+    ["bsc"]="https://safe-transaction-bsc.safe.global"
+    ["celo"]="https://safe-transaction-celo.safe.global"
+    ["ethereum"]="https://safe-transaction-mainnet.safe.global"
+    ["gnosis"]="https://safe-transaction-gnosis-chain.safe.global"
+    ["gnosis-chiado"]="https://safe-transaction-chiado.safe.global"
+    ["linea"]="https://safe-transaction-linea.safe.global"
+    ["mantle"]="https://safe-transaction-mantle.safe.global"
+    ["optimism"]="https://safe-transaction-optimism.safe.global"
+    ["polygon"]="https://safe-transaction-polygon.safe.global"
+    ["polygon-zkevm"]="https://safe-transaction-zkevm.safe.global"
+    ["scroll"]="https://safe-transaction-scroll.safe.global"
+    ["sepolia"]="https://safe-transaction-sepolia.safe.global"
+    ["worldchain"]="https://safe-transaction-worldchain.safe.global"
+    ["xlayer"]="https://safe-transaction-xlayer.safe.global"
+    ["zksync"]="https://safe-transaction-zksync.safe.global"
 )
 
 # Define the chain IDs of the supported networks from the Safe transaction service.
-declare -A CHAIN_IDS=(
-    [arbitrum]=42161
-    [aurora]=1313161554
-    [avalanche]=43114
-    [base]=8453
-    [base-sepolia]=84532
-    [blast]=81457
-    [bsc]=56
-    [celo]=42220
-    [ethereum]=1
-    [gnosis]=100
-    [gnosis-chiado]=10200
-    [linea]=59144
-    [mantle]=5000
-    [optimism]=10
-    [polygon]=137
-    [polygon-zkevm]=1101
-    [scroll]=534352
-    [sepolia]=11155111
-    [worldchain]=480
-    [xlayer]=195
-    [zksync]=324
+declare -A -r CHAIN_IDS=(
+    ["arbitrum"]="42161"
+    ["aurora"]="1313161554"
+    ["avalanche"]="43114"
+    ["base"]="8453"
+    ["base-sepolia"]="84532"
+    ["blast"]="81457"
+    ["bsc"]="56"
+    ["celo"]="42220"
+    ["ethereum"]="1"
+    ["gnosis"]="100"
+    ["gnosis-chiado"]="10200"
+    ["linea"]="59144"
+    ["mantle"]="5000"
+    ["optimism"]="10"
+    ["polygon"]="137"
+    ["polygon-zkevm"]="1101"
+    ["scroll"]="534352"
+    ["sepolia"]="11155111"
+    ["worldchain"]="480"
+    ["xlayer"]="195"
+    ["zksync"]="324"
 )
 
 # Utility function to display the usage information.
 usage() {
-    echo "Usage: $0 [--help] [--list-networks] --network <network> --address <address> --nonce <nonce> [--output <format>]"
-    echo
-    echo "Options:"
-    echo "  --help              Display this help message"
-    echo "  --list-networks     List all supported networks and their chain IDs"
-    echo "  --network <network> Specify the network (required)"
-    echo "  --address <address> Specify the Safe multisig address (required)"
-    echo "  --nonce <nonce>     Specify the transaction nonce (required)"
-    echo "  --output <format>   Specify the output format: 'json' or 'terminal' (default: terminal)"
-    echo
-    echo "Example:"
-    echo "  $0 --network ethereum --address 0x1234...5678 --nonce 42 --output json"
-    exit 1
+    cat <<EOF
+Usage: $0 [--help] [--list-networks] [--json]
+       --network <network> --address <address> --nonce <nonce>
+       --message <file>
+
+Options:
+  --help              Display this help message
+  --list-networks     List all supported networks and their chain IDs
+  --network <network> Specify the network (required)
+  --address <address> Specify the Safe multisig address (required)
+  --nonce <nonce>     Specify the transaction nonce (required for transaction hashes)
+  --message <file>    Specify the message file (required for off-chain message hashes)
+  --json              Output results in JSON format
+
+Example for transaction hashes:
+  $0 --network ethereum --address 0x1234...5678 --nonce 42
+
+Example for off-chain message hashes:
+  $0 --network ethereum --address 0x1234...5678 --message message.txt
+
+Example with JSON output:
+  $0 --network ethereum --address 0x1234...5678 --nonce 42 --json
+EOF
+    exit "${1:-1}"
 }
 
 # Utility function to list all supported networks.
 list_networks() {
     echo "Supported Networks:"
-    for network in "${!CHAIN_IDS[@]}"; do
+    for network in $(echo "${!CHAIN_IDS[@]}" | tr " " "\n" | sort); do
         echo "  $network (${CHAIN_IDS[$network]})"
     done
     exit 0
@@ -106,7 +168,7 @@ list_networks() {
 # Utility function to print a section header.
 print_header() {
     local header=$1
-    if [ -t 1 ] && tput sgr0 >/dev/null 2>&1; then
+    if [[ -t 1 ]] && tput sgr0 >/dev/null 2>&1; then
         # Terminal supports formatting.
         printf "\n${UNDERLINE}%s${RESET}\n" "$header"
     else
@@ -119,8 +181,9 @@ print_header() {
 print_field() {
     local label=$1
     local value=$2
-    local empty_line=${3:-false}
-    if [ -t 1 ] && tput sgr0 >/dev/null 2>&1; then
+    local empty_line="${3:-false}"
+
+    if [[ -t 1 ]] && tput sgr0 >/dev/null 2>&1; then
         # Terminal supports formatting.
         printf "%s: ${GREEN}%s${RESET}\n" "$label" "$value"
     else
@@ -129,8 +192,8 @@ print_field() {
     fi
 
     # Print an empty line if requested.
-    if [ "$empty_line" == "true" ]; then
-        echo
+    if [[ "$empty_line" == "true" ]]; then
+        printf "\n"
     fi
 }
 
@@ -138,12 +201,14 @@ print_field() {
 print_transaction_data() {
     local address=$1
     local to=$2
-    local data=$3
-    local message=$4
+    local value=$3
+    local data=$4
+    local message=$5
 
     print_header "Transaction Data"
     print_field "Multisig address" "$address"
     print_field "To" "$to"
+    print_field "Value" "$value"
     print_field "Data" "$data"
     print_field "Encoded message" "$message"
 }
@@ -176,12 +241,80 @@ print_decoded_data() {
         print_field "Method" "0x (ETH Transfer)"
         print_field "Parameters" "[]"
     else
-        method=$(echo "$data_decoded" | jq -r ".method")
-        parameters=$(echo "$data_decoded" | jq -r ".parameters")
+        local method=$(echo "$data_decoded" | jq -r ".method")
+        local parameters=$(echo "$data_decoded" | jq -r ".parameters")
 
         print_field "Method" "$method"
         print_field "Parameters" "$parameters"
+
+        # Check if the called function is sensitive and print a warning in bold.
+        case "$method" in
+        addOwnerWithThreshold | removeOwner | swapOwner | changeThreshold)
+            echo
+            echo -e "${BOLD}${RED}WARNING: The \"$method\" function modifies the owners or threshold of the Safe. Proceed with caution!${RESET}"
+            ;;
+        esac
+
+        # Check for sensitive functions in nested transactions.
+        echo "$parameters" | jq -c ".[] | .valueDecoded[]? | select(.dataDecoded != null)" | while read -r nested_param; do
+            nested_method=$(echo "$nested_param" | jq -r ".dataDecoded.method")
+
+            if [[ "$nested_method" =~ ^(addOwnerWithThreshold|removeOwner|swapOwner|changeThreshold)$ ]]; then
+                echo
+                echo -e "${BOLD}${RED}WARNING: The \"$nested_method\" function modifies the owners or threshold of the Safe! Proceed with caution!${RESET}"
+            fi
+        done
     fi
+}
+
+# Utility function to extract the clean Safe multisig version.
+get_version() {
+    local version=$1
+    # Safe multisig versions can have the format `X.Y.Z+L2`.
+    # Remove any suffix after and including the `+` in the version string for comparison.
+    local clean_version=$(echo "$version" | sed "s/+.*//")
+    echo "$clean_version"
+}
+
+# Utility function to validate the Safe multisig version.
+validate_version() {
+    local version=$1
+    if [[ -z "$version" ]]; then
+        echo "$(tput setaf 3)No Safe multisig contract found for the specified network. Please ensure that you have selected the correct network.$(tput setaf 0)"
+        exit 0
+    fi
+
+    local clean_version=$(get_version "$version")
+
+    # Ensure that the Safe multisig version is `>= 0.1.0`.
+    if [[ "$(printf "%s\n%s" "$clean_version" "0.1.0" | sort -V | head -n1)" == "$clean_version" && "$clean_version" != "0.1.0" ]]; then
+        echo "$(tput setaf 3)Safe multisig version \"${clean_version}\" is not supported!$(tput setaf 0)"
+        exit 0
+    fi
+}
+
+# Utility function to calculate the domain hash.
+calculate_domain_hash() {
+    local version=$1
+    local domain_separator_typehash=$2
+    local domain_hash_args=$3
+
+    # Validate the Safe multisig version.
+    validate_version "$version"
+
+    local clean_version=$(get_version "$version")
+
+    # Safe multisig versions `<= 1.2.0` use a legacy (i.e. without `chainId`) `DOMAIN_SEPARATOR_TYPEHASH` value.
+    # Starting with version `1.3.0`, the `chainId` field was introduced: https://github.com/safe-global/safe-smart-account/pull/264.
+    if [[ "$(printf "%s\n%s" "$clean_version" "1.2.0" | sort -V | head -n1)" == "$clean_version" ]]; then
+        domain_separator_typehash="$DOMAIN_SEPARATOR_TYPEHASH_OLD"
+        domain_hash_args="$domain_separator_typehash, $address"
+    fi
+
+    # Calculate the domain hash.
+    local domain_hash=$(chisel eval "keccak256(abi.encode($domain_hash_args))" |
+        awk '/Data:/ {gsub(/\x1b\[[0-9;]*m/, "", $3); print $3}')
+    echo "$domain_hash"
 }
 
 # Utility function to calculate the domain and message hashes.
@@ -199,123 +332,380 @@ calculate_hashes() {
     local refund_receiver=${11}
     local nonce=${12}
     local data_decoded=${13}
+    local version=${14}
+    local json_mode=${15:-false}
+
+    local domain_separator_typehash="$DOMAIN_SEPARATOR_TYPEHASH"
+    local domain_hash_args="$domain_separator_typehash, $chain_id, $address"
+    local safe_tx_typehash="$SAFE_TX_TYPEHASH"
+
+    # Validate the Safe multisig version.
+    validate_version "$version"
+
+    local clean_version=$(get_version "$version")
 
     # Calculate the domain hash.
-    local domain_hash=$(chisel eval "keccak256(abi.encode($DOMAIN_SEPARATOR_TYPEHASH, $chain_id, $address))" | awk '/Data:/ {gsub(/\x1b\[[0-9;]*m/, "", $3); print $3}')
+    local domain_hash=$(calculate_domain_hash "$version" "$domain_separator_typehash" "$domain_hash_args")
 
     # Calculate the data hash.
     local data_hashed=$(cast keccak "$data")
+
+    # Safe multisig versions `< 1.0.0` use a legacy (i.e. the parameter value `baseGas` was
+    # called `dataGas` previously) `SAFE_TX_TYPEHASH` value. Starting with version `1.0.0`,
+    # `baseGas` was introduced: https://github.com/safe-global/safe-smart-account/pull/90.
+    if [[ "$(printf "%s\n%s" "$clean_version" "1.0.0" | sort -V | head -n1)" == "$clean_version" && "$clean_version" != "1.0.0" ]]; then
+        safe_tx_typehash="$SAFE_TX_TYPEHASH_OLD"
+    fi
+
     # Encode the message.
-    local message=$(cast abi-encode "SafeTxStruct(bytes32,address,uint256,bytes32,uint8,uint256,uint256,uint256,address,address,uint256)" "$SAFE_TX_TYPEHASH" "$to" "$value" "$data_hashed" "$operation" "$safe_tx_gas" "$base_gas" "$gas_price" "$gas_token" "$refund_receiver" "$nonce")
+    local message=$(cast abi-encode "SafeTxStruct(bytes32,address,uint256,bytes32,uint8,uint256,uint256,uint256,address,address,uint256)" \
+        "$safe_tx_typehash" \
+        "$to" \
+        "$value" \
+        "$data_hashed" \
+        "$operation" \
+        "$safe_tx_gas" \
+        "$base_gas" \
+        "$gas_price" \
+        "$gas_token" \
+        "$refund_receiver" \
+        "$nonce")
+
     # Calculate the message hash.
     local message_hash=$(cast keccak "$message")
 
     # Calculate the Safe transaction hash.
-    local safe_tx_hash=$(chisel eval "keccak256(abi.encodePacked(bytes1(0x19), bytes1(0x01), bytes32($domain_hash), bytes32($message_hash)))" | awk '/Data:/ {gsub(/\x1b\[[0-9;]*m/, "", $3); print $3}')
+    local safe_tx_hash=$(chisel eval "keccak256(abi.encodePacked(bytes1(0x19), bytes1(0x01), bytes32($domain_hash), bytes32($message_hash)))" |
+        awk '/Data:/ {gsub(/\x1b\[[0-9;]*m/, "", $3); print $3}')
 
-    # Parse the data_decoded JSON, handle potential errors
-    local method="0x (ETH Transfer)"
-    local parameters="[]"
-    if [ "$data_decoded" != "0x" ] && [ "$data_decoded" != "null" ]; then
-        method=$(echo "$data_decoded" | jq -r '.method // "0x (ETH Transfer)"')
-        parameters=$(echo "$data_decoded" | jq -r '.parameters // [] | @json' 2>/dev/null || echo "[]")
+    if [[ "$json_mode" == "true" ]]; then
+        # Return the values needed for JSON output
+        echo "$domain_hash"
+        echo "$message_hash"
+        echo "$safe_tx_hash"
+        echo "$message"
+        return
     fi
 
-    # Return JSON object
-    jq -n \
-        --arg address "$address" \
-        --arg to "$to" \
-        --arg data "$data" \
-        --arg message "$message" \
-        --arg method "$method" \
-        --argjson parameters "$parameters" \
-        --arg domainHash "$(format_hash "$domain_hash")" \
-        --arg messageHash "$(format_hash "$message_hash")" \
-        --arg safeTxHash "$safe_tx_hash" \
-        '{
-            transactionData: {
-                multisigAddress: $address,
-                to: $to,
-                data: $data,
-                encodedMessage: $message,
-                method: $method,
-                parameters: $parameters
-            },
-            hashes: {
-                domainHash: $domainHash,
-                messageHash: $messageHash,
-                safeTransactionHash: $safeTxHash
-            }
-        }'
+    # Print the retrieved transaction data.
+    print_transaction_data "$address" "$to" "$value" "$data" "$message"
+    # Print the ABI-decoded transaction data.
+    print_decoded_data "$data_decoded"
+    # Print the results with the same formatting for "Domain hash" and "Message hash" as a Ledger hardware device.
+    print_hash_info "$domain_hash" "$message_hash" "$safe_tx_hash"
+}
+
+# Utility function to validate the network name.
+validate_network() {
+    local network="$1"
+    if [[ -z "${API_URLS[$network]:-}" || -z "${CHAIN_IDS[$network]:-}" ]]; then
+        echo -e "${BOLD}${RED}Invalid network name: \"${network}\"${RESET}\n" >&2
+        calculate_safe_tx_hashes --list-networks >&2
+        exit 1
+    fi
 }
 
 # Utility function to retrieve the API URL of the selected network.
 get_api_url() {
-    echo "${API_URLS[$1]:-Invalid network}" || exit 1
+    local network="$1"
+    validate_network "$network"
+    echo "${API_URLS[$network]}"
 }
 
 # Utility function to retrieve the chain ID of the selected network.
 get_chain_id() {
-    echo "${CHAIN_IDS[$1]:-Invalid network}" || exit 1
+    local network="$1"
+    validate_network "$network"
+    echo "${CHAIN_IDS[$network]}"
 }
 
-# Safe Transaction Hashes Calculator
-# This function orchestrates the entire process of calculating the Safe transaction hash:
-# 1. Parses command-line arguments (`network`, `address`, `nonce`).
+# Utility function to validate the multisig address.
+validate_address() {
+    local address="$1"
+    if [[ -z "$address" || ! "$address" =~ ^0x[a-fA-F0-9]{40}$ ]]; then
+        echo -e "${BOLD}${RED}Invalid Ethereum address format: \"${address}\"${RESET}" >&2
+        exit 1
+    fi
+}
+
+# Utility function to validate the transaction nonce.
+validate_nonce() {
+    local nonce="$1"
+    if [[ -z "$nonce" || ! "$nonce" =~ ^[0-9]+$ ]]; then
+        echo -e "${BOLD}${RED}Invalid nonce value: \"${nonce}\". Must be a non-negative integer!${RESET}" >&2
+        exit 1
+    fi
+}
+
+# Utility function to validate the message file.
+validate_message_file() {
+    local message_file="$1"
+    if [[ ! -f "$message_file" ]]; then
+        echo -e "${BOLD}${RED}Message file not found: \"${message_file}\"!${RESET}" >&2
+        exit 1
+    fi
+    if [[ ! -s "$message_file" ]]; then
+        echo -e "${BOLD}${RED}Message file is empty: \"${message_file}\"!${RESET}" >&2
+        exit 1
+    fi
+}
+
+# Utility function to calculate the domain and message hashes for off-chain messages.
+calculate_offchain_message_hashes() {
+    local network=$1
+    local chain_id=$2
+    local address=$3
+    local message_file=$4
+    local version=$5
+
+    validate_message_file "$message_file"
+
+    # Validate the Safe multisig version.
+    validate_version "$version"
+
+    local message_raw=$(< "$message_file")
+    # Normalise line endings to `LF` (`\n`).
+    message_raw=$(echo "$message_raw" | tr -d "\r")
+    local hashed_message=$(cast hash-message "$message_raw")
+
+    local domain_separator_typehash="$DOMAIN_SEPARATOR_TYPEHASH"
+    local domain_hash_args="$domain_separator_typehash, $chain_id, $address"
+
+    # Calculate the domain hash.
+    local domain_hash=$(calculate_domain_hash "$version" "$domain_separator_typehash" "$domain_hash_args")
+
+    # Calculate the message hash.
+    local message_hash=$(chisel eval "keccak256(abi.encode(bytes32($SAFE_MSG_TYPEHASH), keccak256(abi.encode(bytes32($hashed_message)))))" |
+        awk '/Data:/ {gsub(/\x1b\[[0-9;]*m/, "", $3); print $3}')
+
+    # Calculate the Safe message hash.
+    local safe_msg_hash=$(chisel eval "keccak256(abi.encodePacked(bytes1(0x19), bytes1(0x01), bytes32($domain_hash), bytes32($message_hash)))" |
+        awk '/Data:/ {gsub(/\x1b\[[0-9;]*m/, "", $3); print $3}')
+
+    # Calculate and display the hashes.
+    echo "==================================="
+    echo "= Selected Network Configurations ="
+    echo -e "===================================\n"
+    print_field "Network" "$network"
+    print_field "Chain ID" "$chain_id" true
+    echo "===================================="
+    echo "= Message Data and Computed Hashes ="
+    echo "===================================="
+    print_header "Message Data"
+    print_field "Multisig address" "$address"
+    print_field "Message" "$message_raw"
+    print_header "Hashes"
+    print_field "Raw message hash" "$hashed_message"
+    print_field "Domain hash" "$(format_hash "$domain_hash")"
+    print_field "Message hash" "$(format_hash "$message_hash")"
+    print_field "Safe message hash" "$safe_msg_hash"
+}
+
+# Utility function to output transaction results as JSON
+output_transaction_json() {
+    local network=$1
+    local chain_id=$2
+    local address=$3
+    local to=$4
+    local value=$5
+    local data=$6
+    local message=$7
+    local data_decoded=$8
+    local domain_hash=$9
+    local message_hash=${10}
+    local safe_tx_hash=${11}
+
+    jq -n \
+        --arg network "$network" \
+        --arg chain_id "$chain_id" \
+        --arg address "$address" \
+        --arg to "$to" \
+        --arg value "$value" \
+        --arg data "$data" \
+        --arg message "$message" \
+        --arg data_decoded "$data_decoded" \
+        --arg domain_hash "$(format_hash "$domain_hash")" \
+        --arg message_hash "$(format_hash "$message_hash")" \
+        --arg safe_tx_hash "$safe_tx_hash" \
+        '{
+            network: {
+                name: $network,
+                chain_id: $chain_id
+            },
+            transaction: {
+                multisig_address: $address,
+                to: $to,
+                value: $value,
+                data: $data,
+                encoded_message: $message,
+                data_decoded: ($data_decoded | fromjson)
+            },
+            hashes: {
+                domain_hash: $domain_hash,
+                message_hash: $message_hash,
+                safe_transaction_hash: $safe_tx_hash
+            }
+        }'
+}
+
+# Utility function to output message results as JSON
+output_message_json() {
+    local network=$1
+    local chain_id=$2
+    local address=$3
+    local message=$4
+    local raw_message_hash=$5
+    local domain_hash=$6
+    local message_hash=$7
+    local safe_msg_hash=$8
+
+    jq -n \
+        --arg network "$network" \
+        --arg chain_id "$chain_id" \
+        --arg address "$address" \
+        --arg message "$message" \
+        --arg raw_message_hash "$raw_message_hash" \
+        --arg domain_hash "$(format_hash "$domain_hash")" \
+        --arg message_hash "$(format_hash "$message_hash")" \
+        --arg safe_msg_hash "$safe_msg_hash" \
+        '{
+            network: {
+                name: $network,
+                chain_id: $chain_id
+            },
+            message: {
+                multisig_address: $address,
+                content: $message
+            },
+            hashes: {
+                raw_message_hash: $raw_message_hash,
+                domain_hash: $domain_hash,
+                message_hash: $message_hash,
+                safe_message_hash: $safe_msg_hash
+            }
+        }'
+}
+
+# Safe Transaction/Message Hashes Calculator
+# This function orchestrates the entire process of calculating the Safe transaction/message hashes:
+# 1. Parses command-line arguments (`network`, `address`, `nonce`, `message`).
 # 2. Validates that all required parameters are provided.
 # 3. Retrieves the API URL and chain ID for the specified network.
 # 4. Constructs the API endpoint URL.
-# 5. Fetches the transaction data from the Safe transaction service API.
-# 6. Extracts the relevant transaction details from the API response.
-# 7. Calls the `calculate_hashes` function to compute and display the results.
-calculate_safe_tx_hashes() {
-    local network="" address="" nonce="" output_format="terminal"
+# 5. If a message file is provided:
+#    - Validates that no nonce is specified (as it's not applicable for off-chain message hashes).
+#    - Calls `calculate_offchain_message_hashes` to compute and display the message hashes.
+# 6. If a nonce is provided:
+#    - Fetches the transaction data from the Safe transaction service API.
+#    - Extracts the relevant transaction details from the API response.
+#    - Calls the `calculate_hashes` function to compute and display the results.
+calculate_safe_hashes() {
+    # Display the help message if no arguments are provided.
+    if [[ $# -eq 0 ]]; then
+        usage
+    fi
+
+    local network="" address="" nonce="" message_file="" json_output="false"
 
     # Parse the command line arguments.
     while [[ $# -gt 0 ]]; do
         case "$1" in
-            --help) usage ;;
+            --help) usage 0 ;;
             --network) network="$2"; shift 2 ;;
             --address) address="$2"; shift 2 ;;
             --nonce) nonce="$2"; shift 2 ;;
-            --output) output_format="$2"; shift 2 ;;
+            --message) message_file="$2"; shift 2 ;;
+            --json) json_output="true"; shift ;;
             --list-networks) list_networks ;;
             *) echo "Unknown option: $1" >&2; usage ;;
         esac
     done
 
-    # Check if the required parameters are provided.
-    [[ -z "$network" || -z "$address" || -z "$nonce" ]] && usage
+    # Validate if the required parameters have the correct format.
+    validate_network "$network"
+    validate_address "$address"
 
     # Get the API URL and chain ID for the specified network.
     local api_url=$(get_api_url "$network")
     local chain_id=$(get_chain_id "$network")
     local endpoint="${api_url}/api/v1/safes/${address}/multisig-transactions/?nonce=${nonce}"
 
-    # Fetch the transaction data from the API.
-    local response=$(curl -s "$endpoint")
-    local count=$(echo "$response" | jq '.count')
-    local idx=0
+    # Get the Safe multisig version.
+    local version=$(curl -sf "${api_url}/api/v1/safes/${address}/" | jq -r ".version // \"0.0.0\"")
 
-    # Handle no transactions or multiple transactions
-    if [[ $count -eq 0 ]]; then
-        if [[ "$output_format" == "json" ]]; then
-            echo '{"error": "No transaction is available for this nonce!"}'
-        else
-            echo "No transaction is available for this nonce!"
+    # Calculate the domain and message hashes for off-chain messages.
+    if [[ -n "$message_file" ]]; then
+        if [[ -n "$nonce" ]]; then
+            echo -e "${RED}Error: When calculating off-chain message hashes, do not specify a nonce.${RESET}" >&2
+            exit 1
         fi
-        exit 0
-    elif [[ $count -gt 1 ]]; then
-        if [[ "$output_format" == "json" ]]; then
-            echo '{"error": "Several transactions with identical nonce values have been detected. Please check the API endpoint for details.", "endpoint": "'"$endpoint"'"}'
+
+        local message_raw=$(< "$message_file")
+        message_raw=$(echo "$message_raw" | tr -d "\r")
+        local hashed_message=$(cast hash-message "$message_raw")
+        local domain_hash=$(calculate_domain_hash "$version" "$domain_separator_typehash" "$domain_hash_args")
+        local message_hash=$(chisel eval "keccak256(abi.encode(bytes32($SAFE_MSG_TYPEHASH), keccak256(abi.encode(bytes32($hashed_message)))))" |
+            awk '/Data:/ {gsub(/\x1b\[[0-9;]*m/, "", $3); print $3}')
+        local safe_msg_hash=$(chisel eval "keccak256(abi.encodePacked(bytes1(0x19), bytes1(0x01), bytes32($domain_hash), bytes32($message_hash)))" |
+            awk '/Data:/ {gsub(/\x1b\[[0-9;]*m/, "", $3); print $3}')
+
+        if [[ "$json_output" == "true" ]]; then
+            output_message_json "$network" "$chain_id" "$address" "$message_raw" "$hashed_message" "$domain_hash" "$message_hash" "$safe_msg_hash"
         else
-            echo "Warning: Several transactions with identical nonce values have been detected."
-            echo "Please check the API endpoint for details: $endpoint"
+            calculate_offchain_message_hashes "$network" "$chain_id" "$address" "$message_file" "$version"
         fi
         exit 0
     fi
 
-    # Extract transaction data
+    # Validate if the nonce parameter has the correct format.
+    validate_nonce "$nonce"
+
+    # Fetch the transaction data from the API.
+    local response=$(curl -sf "$endpoint")
+    local count=$(echo "$response" | jq -r ".count // \"0\"")
+    local idx=0
+
+    # Inform the user that no transactions are available for the specified nonce.
+    if [[ $count -eq 0 ]]; then
+        echo "$(tput setaf 3)No transaction is available for this nonce!$(tput sgr0)"
+        exit 0
+    # Notify the user about multiple transactions with identical nonce values and prompt for user input.
+    elif [[ $count -gt 1 ]]; then
+        cat <<EOF
+$(tput setaf 3)Several transactions with identical nonce values have been detected.
+This occurrence is normal if you are deliberately replacing an existing transaction.
+However, if your Safe interface displays only a single transaction, this could indicate
+potential irregular activity requiring your attention.$(tput sgr0)
+
+Kindly specify the transaction's array value (available range: 0-$((${count} - 1))).
+You can find the array values at the following endpoint:
+$(tput setaf 2)$endpoint$(tput sgr0)
+
+Please enter the index of the array:
+EOF
+
+        while true; do
+            read -r idx
+
+            # Validate if user input is a number.
+            if ! [[ $idx =~ ^[0-9]+$ ]]; then
+                echo "$(tput setaf 1)Error: Please enter a valid number!$(tput sgr0)"
+                continue
+            fi
+
+            local array_value=$(echo "$response" | jq ".results[$idx]")
+
+            if [[ $array_value == null ]]; then
+                echo "$(tput setaf 1)Error: No transaction found at index $idx. Please try again.$(tput sgr0)"
+                continue
+            fi
+
+            printf "\n"
+
+            break
+        done
+    fi
+
     local to=$(echo "$response" | jq -r ".results[$idx].to // \"0x0000000000000000000000000000000000000000\"")
     local value=$(echo "$response" | jq -r ".results[$idx].value // \"0\"")
     local data=$(echo "$response" | jq -r ".results[$idx].data // \"0x\"")
@@ -328,38 +718,56 @@ calculate_safe_tx_hashes() {
     local nonce=$(echo "$response" | jq -r ".results[$idx].nonce // \"0\"")
     local data_decoded=$(echo "$response" | jq -r ".results[$idx].dataDecoded // \"0x\"")
 
-    # Calculate hashes
-    local result=$(calculate_hashes "$chain_id" "$address" "$to" "$value" "$data" "$operation" "$safe_tx_gas" "$base_gas" "$gas_price" "$gas_token" "$refund_receiver" "$nonce" "$data_decoded")
-
-    if [[ "$output_format" == "json" ]]; then
-        # Output JSON directly
-        echo "$result"
+    # Calculate and display the hashes.
+    if [[ "$json_output" == "true" ]]; then
+        # Calculate hashes and capture all returned values
+        {
+            read -r domain_hash
+            read -r message_hash
+            read -r safe_tx_hash
+            read -r encoded_message
+        } < <(calculate_hashes "$chain_id" \
+            "$address" \
+            "$to" \
+            "$value" \
+            "$data" \
+            "$operation" \
+            "$safe_tx_gas" \
+            "$base_gas" \
+            "$gas_price" \
+            "$gas_token" \
+            "$refund_receiver" \
+            "$nonce" \
+            "$data_decoded" \
+            "$version" \
+            "true")
+            
+        output_transaction_json "$network" "$chain_id" "$address" "$to" "$value" "$data" "$encoded_message" "$data_decoded" "$domain_hash" "$message_hash" "$safe_tx_hash"
     else
-        # Format and print terminal-friendly output
         echo "==================================="
         echo "= Selected Network Configurations ="
-        echo "==================================="
-        echo
-        echo "Network: $network"
-        echo "Chain ID: $chain_id"
-        echo
+        echo -e "===================================\n"
+        print_field "Network" "$network"
+        print_field "Chain ID" "$chain_id" true
         echo "========================================"
         echo "= Transaction Data and Computed Hashes ="
         echo "========================================"
-        echo
-        echo "Transaction Data"
-        echo "Multisig address: $address"
-        echo "To: $to"
-        echo "Data: $data"
-        echo "Encoded message: $(echo "$result" | jq -r '.transactionData.encodedMessage')"
-        echo "Method: $(echo "$result" | jq -r '.transactionData.method')"
-        echo "Parameters: $(echo "$result" | jq -r '.transactionData.parameters | @json')"
-        echo
-        echo "Hashes"
-        echo "Domain hash: $(echo "$result" | jq -r '.hashes.domainHash')"
-        echo "Message hash: $(echo "$result" | jq -r '.hashes.messageHash')"
-        echo "Safe transaction hash: $(echo "$result" | jq -r '.hashes.safeTransactionHash')"
+        
+        calculate_hashes "$chain_id" \
+            "$address" \
+            "$to" \
+            "$value" \
+            "$data" \
+            "$operation" \
+            "$safe_tx_gas" \
+            "$base_gas" \
+            "$gas_price" \
+            "$gas_token" \
+            "$refund_receiver" \
+            "$nonce" \
+            "$data_decoded" \
+            "$version"
     fi
 }
 
-calculate_safe_tx_hashes "$@"
+calculate_safe_hashes "$@"


### PR DESCRIPTION
## Description

This PR updates the script to support Safe versions `≤ 1.2.0`, which use a different domain separator logic. In these versions, the `DOMAIN_SEPARATOR_TYPEHASH` does not include the `chainId`, leading to differences in how transaction hashes are generated and validated.

### Changes Implemented

- Added compatibility for legacy domain separator logic used in Safe v1.2.0 and earlier.
- Ensured that transactions from these versions can be correctly processed without breaking functionality for newer versions.

### Motivation

This update is necessary for seamless transaction hash verification across different Safe contract versions, ensuring broader usability for older deployments.

### Additional Context

This PR is based on [pcaversaccio/safe-tx-hashes-util#8](https://github.com/pcaversaccio/safe-tx-hashes-util/pull/8) and extends its functionality by integrating it into my fork, which includes additional improvements and a website interface for ease of use.